### PR TITLE
adding contract poller in service framework

### DIFF
--- a/contract_poller/api.go
+++ b/contract_poller/api.go
@@ -1,0 +1,33 @@
+package contract_poller
+
+import "context"
+
+func (p *Poller) Insights() map[string]map[string]int {
+	return map[string]map[string]int{
+		"fetch-pool":      p.fetchPool.Insights(),
+		"accumulate-pool": p.accumulatePool.Insights(),
+		"write-pool":      p.writePool.Insights(),
+	}
+}
+
+func (p *Poller) Pause() {
+	p.modeMu.Lock()
+	defer p.modeMu.Unlock()
+
+	p.writePool.FlushAndRestart()
+	p.accumulatePool.FlushAndRestart()
+	p.fetchPool.FlushAndRestart()
+
+	p.mode = ModePaused
+}
+
+func (p *Poller) Resume() {
+	p.modeMu.Lock()
+	defer p.modeMu.Unlock()
+
+	p.mode = ModeReady
+}
+
+func (p *Poller) SetCursor(ctx context.Context, newVal uint64) error {
+	return p.cache.SetCurrentBlockNumber(ctx, p.cacheKey(), newVal)
+}

--- a/contract_poller/config.go
+++ b/contract_poller/config.go
@@ -1,0 +1,16 @@
+package contract_poller
+
+import (
+	"github.com/datadaodevs/go-service-framework/constants"
+	"time"
+)
+
+type Config struct {
+	Blockchain  constants.Blockchain `env:"BLOCKCHAIN,required"`
+	BatchSize   int                  `env:"BATCH_SIZE" envDefault:"100"`
+	ReorgDepth  int                  `env:"REORG_DEPTH" envDefault:"8"`
+	HttpRetries int                  `env:"HTTP_RETRIES" envDefault:"10"`
+	SleepTime   time.Duration        `env:"POLLER_SLEEP_TIME" envDefault:"12s"`
+	Tick        time.Duration        `env:"POLLER_TICK_DURATION" envDefault:"1s"`
+	AutoStart   bool                 `env:"POLLER_AUTO_START" envDefault:"false"`
+}

--- a/contract_poller/config.go
+++ b/contract_poller/config.go
@@ -1,7 +1,7 @@
 package contract_poller
 
 import (
-	"github.com/datadaodevs/go-service-framework/constants"
+	"github.com/coherentopensource/go-service-framework/constants"
 	"time"
 )
 

--- a/contract_poller/deps.go
+++ b/contract_poller/deps.go
@@ -8,8 +8,8 @@ import (
 type Driver interface {
 	Blockchain() string
 	GetChainTipNumber(ctx context.Context) (uint64, error)
-	// FetchSequenceForContract involves fetching trace from node, abi from contract source, and metadata from node in a sequential manner
-	FetchSequenceForContract(index uint64) map[string]pool.Runner
+	// FetchContractAddresses involves fetching trace from ethrpc node
+	FetchContractAddresses(index uint64) map[string]pool.Runner
 	// Accumulate involves combining abi, metadata to form a complete contract, building fragments
 	Accumulate(res interface{}) pool.Runner
 	// Writers involves writing to postgresDB

--- a/contract_poller/deps.go
+++ b/contract_poller/deps.go
@@ -8,8 +8,8 @@ import (
 type Driver interface {
 	Blockchain() string
 	GetChainTipNumber(ctx context.Context) (uint64, error)
-	// FetchSequence involves fetching trace from node, abi from contract source, and metadata from node
-	FetchSequence(index uint64) map[string]pool.Runner
+	// FetchSequenceForContract involves fetching trace from node, abi from contract source, and metadata from node in a sequential manner
+	FetchSequenceForContract(index uint64) map[string]pool.Runner
 	// Accumulate involves combining abi, metadata to form a complete contract, building fragments
 	Accumulate(res interface{}) pool.Runner
 	// Writers involves writing to postgresDB

--- a/contract_poller/deps.go
+++ b/contract_poller/deps.go
@@ -9,7 +9,9 @@ type Driver interface {
 	Blockchain() string
 	GetChainTipNumber(ctx context.Context) (uint64, error)
 	// FetchContractAddresses involves fetching trace from ethrpc node
-	FetchContractAddresses(index uint64) map[string]pool.Runner
+	FetchContractAddresses(blockNumber uint64) map[string]pool.Runner
+	// FetchContractMetadata involves fetching contract's abi and metadata, using results from FetchContractAddresses
+	FetchContractMetadata() map[string]pool.FeedTransformer
 	// Accumulate involves combining abi, metadata to form a complete contract, building fragments
 	Accumulate(res interface{}) pool.Runner
 	// Writers involves writing to postgresDB

--- a/contract_poller/deps.go
+++ b/contract_poller/deps.go
@@ -1,0 +1,20 @@
+package contract_poller
+
+import (
+	"context"
+	"github.com/datadaodevs/go-service-framework/pool"
+)
+
+type Driver interface {
+	Blockchain() string
+	GetChainTipNumber(ctx context.Context) (uint64, error)
+	IsValidBlock(ctx context.Context, index uint64) error
+	FetchSequence(index uint64) map[string]pool.Runner
+	Accumulate(res interface{}) pool.Runner
+	Writers() []pool.FeedTransformer
+}
+
+type Cache interface {
+	GetCurrentBlockNumber(ctx context.Context, blockChainInfoKey string) (uint64, error)
+	SetCurrentBlockNumber(ctx context.Context, blockChainInfoKey string, blockNumber uint64) error
+}

--- a/contract_poller/deps.go
+++ b/contract_poller/deps.go
@@ -2,7 +2,7 @@ package contract_poller
 
 import (
 	"context"
-	"github.com/datadaodevs/go-service-framework/pool"
+	"github.com/coherentopensource/go-service-framework/pool"
 )
 
 type Driver interface {

--- a/contract_poller/deps.go
+++ b/contract_poller/deps.go
@@ -8,9 +8,11 @@ import (
 type Driver interface {
 	Blockchain() string
 	GetChainTipNumber(ctx context.Context) (uint64, error)
-	IsValidBlock(ctx context.Context, index uint64) error
+	// FetchSequence involves fetching trace from node, abi from contract source, and metadata from node
 	FetchSequence(index uint64) map[string]pool.Runner
+	// Accumulate involves combining abi, metadata to form a complete contract, building fragments
 	Accumulate(res interface{}) pool.Runner
+	// Writers involves writing to postgresDB
 	Writers() []pool.FeedTransformer
 }
 

--- a/contract_poller/options.go
+++ b/contract_poller/options.go
@@ -1,8 +1,8 @@
 package contract_poller
 
 import (
-	"github.com/datadaodevs/go-service-framework/pool"
-	"github.com/datadaodevs/go-service-framework/util"
+	"github.com/coherentopensource/go-service-framework/pool"
+	"github.com/coherentopensource/go-service-framework/util"
 )
 
 type opt func(p *Poller)

--- a/contract_poller/options.go
+++ b/contract_poller/options.go
@@ -1,0 +1,39 @@
+package contract_poller
+
+import (
+	"github.com/datadaodevs/go-service-framework/pool"
+	"github.com/datadaodevs/go-service-framework/util"
+)
+
+type opt func(p *Poller)
+
+func WithFetchPool(wp *pool.WorkerPool) opt {
+	return func(p *Poller) {
+		p.fetchPool = wp
+	}
+}
+func WithAccumulatePool(wp *pool.WorkerPool) opt {
+	return func(p *Poller) {
+		p.accumulatePool = wp
+	}
+}
+func WithWritePool(wp *pool.WorkerPool) opt {
+	return func(p *Poller) {
+		p.writePool = wp
+	}
+}
+func WithCache(c Cache) opt {
+	return func(p *Poller) {
+		p.cache = c
+	}
+}
+func WithLogger(logger util.Logger) opt {
+	return func(p *Poller) {
+		p.logger = logger
+	}
+}
+func WithMetrics(metrics util.Metrics) opt {
+	return func(p *Poller) {
+		p.metrics = metrics
+	}
+}

--- a/contract_poller/poller.go
+++ b/contract_poller/poller.go
@@ -115,12 +115,6 @@ func (p *Poller) Start(ctx context.Context) error {
 			case ModeChaintip:
 				//	If in "chaintip" mode, pull the latest block, validate it, then consume it
 				p.logger.Infof("Chaintip mode: pulling block %d", cursor)
-				if p.driver.IsValidBlock(ctx, cursor); err != nil {
-					p.logger.Errorf("Invalid block (possible reorg detected) - %v", err)
-					//	Sleep for N seconds if invalid block is detected
-					p.setSleepMode()
-					continue
-				}
 				wg := sync.WaitGroup{}
 				wg.Add(p.driverTaskLoad())
 				p.fetchPool.PushGroup(p.driver.FetchSequence(cursor), &wg)

--- a/contract_poller/poller.go
+++ b/contract_poller/poller.go
@@ -2,8 +2,8 @@ package contract_poller
 
 import (
 	"context"
-	"github.com/datadaodevs/go-service-framework/pool"
-	"github.com/datadaodevs/go-service-framework/util"
+	"github.com/coherentopensource/go-service-framework/pool"
+	"github.com/coherentopensource/go-service-framework/util"
 	"sync"
 	"time"
 )

--- a/contract_poller/poller.go
+++ b/contract_poller/poller.go
@@ -108,7 +108,7 @@ func (p *Poller) Start(ctx context.Context) error {
 				startIndex := cursor
 				for i := 0; i < p.cfg.BatchSize; i++ {
 					wg.Add(p.driverTaskLoad())
-					p.fetchPool.PushGroup(p.driver.FetchSequenceForContract(cursor), &wg)
+					p.fetchPool.PushGroup(p.driver.FetchContractAddresses(cursor), &wg)
 				}
 				wg.Wait()
 				cursor = startIndex + uint64(p.cfg.BatchSize)
@@ -117,7 +117,7 @@ func (p *Poller) Start(ctx context.Context) error {
 				p.logger.Infof("Chaintip mode: pulling block %d", cursor)
 				wg := sync.WaitGroup{}
 				wg.Add(p.driverTaskLoad())
-				p.fetchPool.PushGroup(p.driver.FetchSequenceForContract(cursor), &wg)
+				p.fetchPool.PushGroup(p.driver.FetchContractAddresses(cursor), &wg)
 				wg.Wait()
 				cursor++
 			}

--- a/contract_poller/poller.go
+++ b/contract_poller/poller.go
@@ -70,7 +70,7 @@ func (p *Poller) Start(ctx context.Context) error {
 	p.runCtx = ctx
 	p.cancelFunc = cancel
 
-	p.logger.Infof("Main poller worker starting for blockchain [%s]", p.driver.Blockchain())
+	p.logger.Infof("Contract poller worker starting for blockchain [%s]", p.driver.Blockchain())
 	go func() {
 		for {
 			//	Check for context cancellation
@@ -103,12 +103,12 @@ func (p *Poller) Start(ctx context.Context) error {
 				continue
 			case ModeBackfill:
 				//	If in ""backfill" mode, consume a batch of blocks and update the cursor
-				p.logger.Infof("Batch mode: start polling at block %d with batch size %d", cursor, p.cfg.BatchSize)
+				p.logger.Infof("Batch mode: start polling contracts at block %d with batch size %d", cursor, p.cfg.BatchSize)
 				wg := sync.WaitGroup{}
 				startIndex := cursor
 				for i := 0; i < p.cfg.BatchSize; i++ {
 					wg.Add(p.driverTaskLoad())
-					p.fetchPool.PushGroup(p.driver.FetchSequence(startIndex+uint64(i)), &wg)
+					p.fetchPool.PushGroup(p.driver.FetchSequenceForContract(cursor), &wg)
 				}
 				wg.Wait()
 				cursor = startIndex + uint64(p.cfg.BatchSize)
@@ -117,7 +117,7 @@ func (p *Poller) Start(ctx context.Context) error {
 				p.logger.Infof("Chaintip mode: pulling block %d", cursor)
 				wg := sync.WaitGroup{}
 				wg.Add(p.driverTaskLoad())
-				p.fetchPool.PushGroup(p.driver.FetchSequence(cursor), &wg)
+				p.fetchPool.PushGroup(p.driver.FetchSequenceForContract(cursor), &wg)
 				wg.Wait()
 				cursor++
 			}

--- a/contract_poller/poller.go
+++ b/contract_poller/poller.go
@@ -1,0 +1,152 @@
+package contract_poller
+
+import (
+	"context"
+	"github.com/datadaodevs/go-service-framework/pool"
+	"github.com/datadaodevs/go-service-framework/util"
+	"sync"
+	"time"
+)
+
+// Modes determine what the poller does on each iteration of its main routine's loop; these are determined by
+// the distance of the cursor from chaintip and the success/failure state of the previous iteration
+const (
+	//	ModeReady means the poller is ready to have its mode reassessed based on chaintip position
+	ModeReady = iota
+	//	ModeSleep means the poller is within reorg depth and is waiting to chaintip to progress before reassessing
+	ModeSleep
+	//	ModePaused means the poller has been manually paused - it will stay in this state until manually resumed
+	ModePaused
+	//	ModeBackfill means the poller is >= batchSize blocks from chaintip and will pull a batch of past blocks
+	ModeBackfill
+	//	ModeChaintip means the poller is < batchSize blocks from chaintip and will pull one block at a time
+	ModeChaintip
+)
+
+// Poller is a chain-agnostic module for ETLing blockchain data, utilizing worker pools to optimize
+// efficiency and speed
+type Poller struct {
+	modeMu         *sync.Mutex
+	logger         util.Logger
+	metrics        util.Metrics
+	cfg            *Config
+	mode           int
+	driver         Driver
+	cache          Cache
+	fetchPool      *pool.WorkerPool
+	accumulatePool *pool.WorkerPool
+	writePool      *pool.WorkerPool
+	cancelFunc     context.CancelFunc
+	runCtx         context.Context
+}
+
+// New constructs a new poller, given a config, a chain-specific driver, and a variadic array of options
+func New(cfg *Config, driver Driver, opts ...opt) *Poller {
+	startMode := ModePaused
+	if cfg.AutoStart {
+		startMode = ModeReady
+	}
+
+	p := Poller{
+		cfg:    cfg,
+		driver: driver,
+		modeMu: &sync.Mutex{},
+		mode:   startMode,
+	}
+	for _, opt := range opts {
+		opt(&p)
+	}
+
+	p.accumulatePool.SetInputFeed(p.fetchPool.Results(), p.driver.Accumulate)
+	p.writePool.SetInputFeed(p.accumulatePool.Results(), p.driver.Writers()...)
+
+	return &p
+}
+
+// Run executes the main program loop inside of a dedicated goroutine; the loop can be terminated from the
+// outside via context cancellation
+func (p *Poller) Start(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	p.runCtx = ctx
+	p.cancelFunc = cancel
+
+	p.logger.Infof("Main poller worker starting for blockchain [%s]", p.driver.Blockchain())
+	go func() {
+		for {
+			//	Check for context cancellation
+			select {
+			default:
+			case <-ctx.Done():
+				p.logger.Warn("Context cancelled; poller will now stop")
+				return
+			}
+
+			//	Deduce mode and get "cursor" representing the current local chaintip
+			start := time.Now()
+			cursor, err := p.setModeAndGetCursor(ctx)
+			if err != nil {
+				p.logger.Errorf("Error setting mode: %v", err)
+				continue
+			}
+
+			p.logger.Infof("Top of main loop; mode is [%s]; cursor is [%d]", modeToString(p.mode), cursor)
+
+			switch p.mode {
+			case ModePaused:
+				p.logger.Info("Paused mode detected; sleeping for this cycle")
+				time.Sleep(1 * time.Second)
+				continue
+			case ModeSleep:
+				//	If in "sleep" mode, hold for 1 second then start another iteration of the main loop
+				p.logger.Info("Sleep mode detected; sleeping for this cycle")
+				time.Sleep(1 * time.Second)
+				continue
+			case ModeBackfill:
+				//	If in ""backfill" mode, consume a batch of blocks and update the cursor
+				p.logger.Infof("Batch mode: start polling at block %d with batch size %d", cursor, p.cfg.BatchSize)
+				wg := sync.WaitGroup{}
+				startIndex := cursor
+				for i := 0; i < p.cfg.BatchSize; i++ {
+					wg.Add(p.driverTaskLoad())
+					p.fetchPool.PushGroup(p.driver.FetchSequence(startIndex+uint64(i)), &wg)
+				}
+				wg.Wait()
+				cursor = startIndex + uint64(p.cfg.BatchSize)
+			case ModeChaintip:
+				//	If in "chaintip" mode, pull the latest block, validate it, then consume it
+				p.logger.Infof("Chaintip mode: pulling block %d", cursor)
+				if p.driver.IsValidBlock(ctx, cursor); err != nil {
+					p.logger.Errorf("Invalid block (possible reorg detected) - %v", err)
+					//	Sleep for N seconds if invalid block is detected
+					p.setSleepMode()
+					continue
+				}
+				wg := sync.WaitGroup{}
+				wg.Add(p.driverTaskLoad())
+				p.fetchPool.PushGroup(p.driver.FetchSequence(cursor), &wg)
+				wg.Wait()
+				cursor++
+			}
+
+			//	Cache new cursor value
+			if err := p.setCurrentChaintip(ctx, cursor); err != nil {
+				p.logger.Errorf("failed to update block chain tip within redis: %v", err)
+				continue
+			}
+
+			//	Log/stat update
+			p.logger.Infof("finished polling at block %d with batch size %d", cursor, p.cfg.BatchSize)
+			p.metrics.Gauge("keep_up_with_chain_tip", float64(time.Since(start).Milliseconds()), []string{}, 1.0)
+		}
+	}()
+
+	return nil
+}
+
+func (p *Poller) Stop() {
+	p.cancelFunc()
+}
+
+func (p *Poller) Mode() int {
+	return p.mode
+}

--- a/contract_poller/sequencing.go
+++ b/contract_poller/sequencing.go
@@ -1,0 +1,93 @@
+package contract_poller
+
+import (
+	"context"
+	"github.com/datadaodevs/go-service-framework/retry"
+	"github.com/pkg/errors"
+	"time"
+)
+
+// setModeAndGetCursor uses the delta between local and remote chaintip values to deduce whether poller
+// should run in backfill mode, chaintip mode, or sleep mode (if not enough blocks are finalized), then
+// returns the current cursor
+func (p *Poller) setModeAndGetCursor(ctx context.Context) (uint64, error) {
+	p.modeMu.Lock()
+	defer p.modeMu.Unlock()
+
+	cursor, err := p.getCurrentChaintip(ctx)
+	if err != nil {
+		return 0, errors.Errorf("Error getting current chaintip: %v", err)
+	}
+
+	if p.mode == ModePaused || p.mode == ModeSleep {
+		return cursor, nil
+	}
+
+	chainTip, err := p.getRemoteChaintip(ctx)
+	if err != nil {
+		return 0, errors.Errorf("Error getting remote chaintip: %v", err)
+	}
+
+	maxBlock := chainTip - uint64(p.cfg.ReorgDepth)
+	distanceToMaxBlock := maxBlock - cursor
+
+	switch {
+	//	Cursor is within reorg
+	case cursor >= maxBlock:
+		p.setSleepMode()
+		p.logger.Warn("Cursor is within reorg range; poller going to sleep")
+	// Cursor is close enough that we should be in Chaintip mode
+	case distanceToMaxBlock < uint64(p.cfg.BatchSize):
+		p.mode = ModeChaintip
+	//	Cursor is distant enough from chaintip that we can pull batches
+	default:
+		p.mode = ModeBackfill
+	}
+
+	return cursor, nil
+}
+
+// getCurrentChaintip pulls the current local chaintip from cache
+func (p *Poller) getCurrentChaintip(ctx context.Context) (uint64, error) {
+	currentTip, err := p.cache.GetCurrentBlockNumber(ctx, p.cacheKey())
+	if err != nil {
+		p.logger.Errorf("error thrown getting chain tip from redis: %v", err)
+		return 0, err
+	}
+	return currentTip, nil
+}
+
+// setCurrentChaintip overwrites the current cached local chaintip value
+func (p *Poller) setCurrentChaintip(ctx context.Context, newTip uint64) error {
+	return retry.Exec(p.cfg.HttpRetries, func() error {
+		return p.cache.SetCurrentBlockNumber(ctx, p.cacheKey(), newTip)
+	}, nil)
+}
+
+// getRemoteChaintip pulls the remote chaintip value
+func (p *Poller) getRemoteChaintip(ctx context.Context) (uint64, error) {
+	var chainTip uint64
+	var err error
+	retry.Exec(p.cfg.HttpRetries, func() error {
+		chainTip, err = p.driver.GetChainTipNumber(ctx)
+		if err != nil {
+			return err
+		}
+		return nil
+	}, nil)
+	return chainTip, err
+}
+
+// setSleepMode puts the poller to sleep for a configurable number of seconds, then resets it to
+// "ready" mode so the next iteration can freshly assess what mode it should switch to
+func (p *Poller) setSleepMode() {
+	p.mode = ModeSleep
+	go func() {
+		select {
+		case <-p.runCtx.Done():
+			return
+		case <-time.Tick(p.cfg.SleepTime):
+			p.mode = ModeReady
+		}
+	}()
+}

--- a/contract_poller/sequencing.go
+++ b/contract_poller/sequencing.go
@@ -2,7 +2,7 @@ package contract_poller
 
 import (
 	"context"
-	"github.com/datadaodevs/go-service-framework/retry"
+	"github.com/coherentopensource/go-service-framework/retry"
 	"github.com/pkg/errors"
 	"time"
 )

--- a/contract_poller/util.go
+++ b/contract_poller/util.go
@@ -11,7 +11,7 @@ func (p *Poller) cacheKey() string {
 
 func (p *Poller) driverTaskLoad() int {
 	//	count of fetchers + count of accumulators (always 1) + count of writers == number of queued jobs per block
-	return len(p.driver.FetchSequenceForContract(0)) + 1 + len(p.driver.Writers())
+	return len(p.driver.FetchContractAddresses(0)) + 1 + len(p.driver.Writers())
 }
 
 func modeToString(mode int) string {

--- a/contract_poller/util.go
+++ b/contract_poller/util.go
@@ -11,7 +11,7 @@ func (p *Poller) cacheKey() string {
 
 func (p *Poller) driverTaskLoad() int {
 	//	count of fetchers + count of accumulators (always 1) + count of writers == number of queued jobs per block
-	return len(p.driver.FetchSequence(0)) + 1 + len(p.driver.Writers())
+	return len(p.driver.FetchSequenceForContract(0)) + 1 + len(p.driver.Writers())
 }
 
 func modeToString(mode int) string {

--- a/contract_poller/util.go
+++ b/contract_poller/util.go
@@ -1,0 +1,32 @@
+package contract_poller
+
+import (
+	"fmt"
+	"github.com/datadaodevs/go-service-framework/constants"
+)
+
+func (p *Poller) cacheKey() string {
+	return fmt.Sprintf("contract_poller-%s-%s", p.driver.Blockchain(), constants.BlockKey)
+}
+
+func (p *Poller) driverTaskLoad() int {
+	//	count of fetchers + count of accumulators (always 1) + count of writers == number of queued jobs per block
+	return len(p.driver.FetchSequence(0)) + 1 + len(p.driver.Writers())
+}
+
+func modeToString(mode int) string {
+	out := "unknown"
+	switch mode {
+	case ModePaused:
+		out = "paused"
+	case ModeSleep:
+		out = "sleep"
+	case ModeReady:
+		out = "ready"
+	case ModeBackfill:
+		out = "backfill"
+	case ModeChaintip:
+		out = "chaintip"
+	}
+	return out
+}

--- a/contract_poller/util.go
+++ b/contract_poller/util.go
@@ -2,7 +2,7 @@ package contract_poller
 
 import (
 	"fmt"
-	"github.com/datadaodevs/go-service-framework/constants"
+	"github.com/coherentopensource/go-service-framework/constants"
 )
 
 func (p *Poller) cacheKey() string {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/segmentio/ksuid v1.0.4
-	github.com/sirupsen/logrus v1.7.0
 	google.golang.org/grpc v1.54.0
 )
 


### PR DESCRIPTION
This PR implements a poller, similar to our existing poller module for contract service. Contract Service will poll for traces to determine newly deployed contracts, and leveraging the framework's worker pools, it will have two fetcher pools to fetch traces from rpc node, and to fetch ABI and metadata for the new contracts.
