### PR TITLE
parameterize cursor key

### DIFF
--- a/poller/config.go
+++ b/poller/config.go
@@ -1,8 +1,9 @@
 package poller
 
 import (
-	"github.com/coherentopensource/go-service-framework/constants"
 	"time"
+
+	"github.com/coherentopensource/go-service-framework/constants"
 )
 
 type Config struct {
@@ -13,4 +14,5 @@ type Config struct {
 	SleepTime   time.Duration        `env:"POLLER_SLEEP_TIME" envDefault:"12s"`
 	Tick        time.Duration        `env:"POLLER_TICK_DURATION" envDefault:"1s"`
 	AutoStart   bool                 `env:"POLLER_AUTO_START" envDefault:"false"`
+	CursorKey   string               `env:"CURSOR_KEY" envDefault:""`
 }

--- a/poller/deps.go
+++ b/poller/deps.go
@@ -2,6 +2,7 @@ package poller
 
 import (
 	"context"
+
 	"github.com/coherentopensource/go-service-framework/pool"
 )
 

--- a/poller/sequencing.go
+++ b/poller/sequencing.go
@@ -2,9 +2,10 @@ package poller
 
 import (
 	"context"
+	"time"
+
 	"github.com/coherentopensource/go-service-framework/retry"
 	"github.com/pkg/errors"
-	"time"
 )
 
 // setModeAndGetCursor uses the delta between local and remote chaintip values to deduce whether poller

--- a/poller/util.go
+++ b/poller/util.go
@@ -1,12 +1,7 @@
 package poller
 
-import (
-	"fmt"
-	"github.com/coherentopensource/go-service-framework/constants"
-)
-
 func (p *Poller) cacheKey() string {
-	return fmt.Sprintf("%s-%s", p.driver.Blockchain(), constants.BlockKey)
+	return p.cursorKey
 }
 
 func (p *Poller) driverTaskLoad() int {


### PR DESCRIPTION
* parametrized the cursor/cache key. 
  * this will allow poller drivers to use the same code for mainnet and testnet 
  * or even allow us to spin up multiple pollers for the same blockchain to speed up backfills (eg. ethereum-1, ethereum-2, etc).