### PR TITLE
SetGroupInputFeed functionality

### DIFF
--- a/pool/pool.go
+++ b/pool/pool.go
@@ -103,6 +103,11 @@ func (wp *WorkerPool) FlushAndRestart() {
 // SetInputFeed configures the workerpool to receive jobs from an input channel, with "transformer" methods
 // that convert a generic input interface into a Runner
 func (wp *WorkerPool) SetInputFeed(feed <-chan result, transformers ...FeedTransformer) {
+	if wp.feedCh != nil {
+		wp.logger.Warn("Attempting to set input feed, when input feed is already defined")
+		return
+	}
+
 	wp.feedCh = feed
 	wp.feedTransformers = map[string]FeedTransformer{}
 	for _, transformer := range transformers {
@@ -113,6 +118,11 @@ func (wp *WorkerPool) SetInputFeed(feed <-chan result, transformers ...FeedTrans
 // SetGroupInputFeed configures the workerpool to receive jobs from an input channel, with "transformer" methods
 // that convert a generic input interface into a Runner; with the runners executed as a group
 func (wp *WorkerPool) SetGroupInputFeed(feed <-chan result, groupMap map[string]FeedTransformer) {
+	if wp.feedCh != nil {
+		wp.logger.Warn("Attempting to set group input feed, when input feed is already defined")
+		return
+	}
+
 	wp.feedCh = feed
 	wp.feedTransformers = groupMap
 	wp.useGroupForFeed = true

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -169,7 +169,7 @@ func (wp *WorkerPool) startFeeder(ctx context.Context) {
 					case wp.useGroupForFeed:
 						group[id] = transformer(res.payload)
 					default:
-						wp.jobCh <- job{fn: transformer(res.payload), receiptWg: res.wg, id: id}
+						wp.jobCh <- job{fn: transformer(res.payload), receiptWg: res.wg, id: ksuid.New().String()}
 					}
 				}
 				if wp.useGroupForFeed {

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -24,7 +24,8 @@ type WorkerPool struct {
 	groups           map[string]*group
 	groupMu          *sync.Mutex
 	workerWg         *sync.WaitGroup
-	feedTransformers []FeedTransformer
+	feedTransformers map[string]FeedTransformer
+	useGroupForFeed  bool
 	bandwidth        int
 	errHandler       ErrHandler
 	errCh            chan error
@@ -42,6 +43,8 @@ func NewWorkerPool(id string, opts ...opt) *WorkerPool {
 	wp := WorkerPool{
 		id:        id,
 		bandwidth: defaultBandwidth,
+		// this is default anyway, but specifying for explicitness
+		useGroupForFeed: false,
 	}
 	wp.errHandler = wp.defaultErrHandler
 	for _, opt := range opts {
@@ -97,11 +100,22 @@ func (wp *WorkerPool) FlushAndRestart() {
 	wp.Start(wp.parentCtx)
 }
 
-// SetInputFeed configures the workerpool to receive jobs from an input channel, with a "transformer" method
-// that converts a generic input interface into a Runner
+// SetInputFeed configures the workerpool to receive jobs from an input channel, with "transformer" methods
+// that convert a generic input interface into a Runner
 func (wp *WorkerPool) SetInputFeed(feed <-chan result, transformers ...FeedTransformer) {
 	wp.feedCh = feed
-	wp.feedTransformers = transformers
+	wp.feedTransformers = map[string]FeedTransformer{}
+	for _, transformer := range transformers {
+		wp.feedTransformers[ksuid.New().String()] = transformer
+	}
+}
+
+// SetGroupInputFeed configures the workerpool to receive jobs from an input channel, with "transformer" methods
+// that convert a generic input interface into a Runner; with the runners executed as a group
+func (wp *WorkerPool) SetGroupInputFeed(feed <-chan result, groupMap map[string]FeedTransformer) {
+	wp.feedCh = feed
+	wp.feedTransformers = groupMap
+	wp.useGroupForFeed = true
 }
 
 // PushGroup queues a group of Runners for execution, with a receipt signal to be sent to the supplied receiptWg when
@@ -149,8 +163,17 @@ func (wp *WorkerPool) startFeeder(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case res := <-wp.feedCh:
-				for _, transformer := range wp.feedTransformers {
-					wp.jobCh <- job{fn: transformer(res.payload), receiptWg: res.wg, id: ksuid.New().String()}
+				group := map[string]Runner{}
+				for id, transformer := range wp.feedTransformers {
+					switch {
+					case wp.useGroupForFeed:
+						group[id] = transformer(res.payload)
+					default:
+						wp.jobCh <- job{fn: transformer(res.payload), receiptWg: res.wg, id: id}
+					}
+				}
+				if wp.useGroupForFeed {
+					wp.PushGroup(group, res.wg)
 				}
 			}
 		}

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -2,6 +2,7 @@ package pool_test
 
 import (
 	"context"
+	"fmt"
 	"github.com/coherentopensource/go-service-framework/pool"
 	"go.uber.org/zap"
 	"sync"
@@ -107,6 +108,115 @@ func TestChainedWorkerPools(t *testing.T) {
 	//	Check completed versus expected jobs
 	if completedJobs != testRuns*jobsPerRun {
 		t.Errorf("Expected %d completed jobs, but got %d", testRuns*jobsPerRun, completedJobs)
+		return
+	}
+}
+
+func TestGroupFeed(t *testing.T) {
+	//	Increment as the test is set up
+	var totalExpectedJobs int
+
+	//	Instantiate logger
+	midLogger, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatalf("Error instantiating logger: %v", err)
+	}
+	logger := midLogger.Sugar()
+
+	//	Instantiate the pools, with no output channel for the last one
+	pool1 := pool.NewWorkerPool("pool1", pool.WithLogger(logger), pool.WithOutputChannel())
+	pool2 := pool.NewWorkerPool("pool2", pool.WithLogger(logger), pool.WithOutputChannel())
+	pool3 := pool.NewWorkerPool("pool3", pool.WithLogger(logger))
+
+	//	Set up counters to keep track of jobs
+	completedJobs := 0
+	completedJobsMutex := &sync.Mutex{}
+
+	//	Set up a single runner that will lock on the name of the job
+	getRunner := func(jobName string) pool.Runner {
+		return func(ctx context.Context) (interface{}, error) {
+			logger.Infof("[%s]: Starting a job", jobName)
+			time.Sleep(100 * time.Millisecond)
+			completedJobsMutex.Lock()
+			completedJobs++
+			logger.Infof("[%s]: Finishing a job; [%d] jobs completed", jobName, completedJobs)
+			if completedJobs == totalExpectedJobs {
+				logger.Infof("%d jobs have now completed; the test should now exit promptly", totalExpectedJobs)
+			}
+
+			//	if this is the accumulator, it should be the last job run
+			if jobName == "accumulator" {
+				if completedJobs != totalExpectedJobs {
+					t.Fatalf("Expected accumulator to be the %dth job run, but instead it was the %dth", totalExpectedJobs, completedJobs)
+				}
+			}
+
+			completedJobsMutex.Unlock()
+
+			return struct{}{}, nil
+		}
+	}
+
+	//	Wrap the runner in a transformer
+	getTransformer := func(jobName string) pool.FeedTransformer {
+		return func(res interface{}) pool.Runner {
+			return getRunner(jobName)
+		}
+	}
+
+	//	For the middle pool, use a group
+	fns := map[string]pool.FeedTransformer{
+		"fn1": getTransformer("group job1"),
+		"fn2": getTransformer("group job2"),
+		"fn3": getTransformer("group job3"),
+		"fn4": getTransformer("group job4"),
+	}
+	totalExpectedJobs += len(fns)
+
+	//	Pool2 feeds from pool1 using the transformers
+	totalExpectedJobs++
+	pool2.SetGroupInputFeed(
+		pool1.Results(),
+		fns,
+	)
+
+	//	Pool3 feeds from pool2 using the transformer
+	totalExpectedJobs++
+	pool3.SetInputFeed(pool2.Results(), getTransformer("accumulator"))
+
+	//	Prepare to kill all processes if there is a timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	//	Start the pools and defer stopping them
+	pool1.Start(ctx)
+	pool2.Start(ctx)
+	pool3.Start(ctx)
+	defer pool1.Stop()
+	defer pool2.Stop()
+	defer pool3.Stop()
+
+	//	Queue work into pool1
+	logger.Infof("Starting group pushes; expect %d jobs to run, with accumulator last", totalExpectedJobs)
+	wg := &sync.WaitGroup{}
+	wg.Add(totalExpectedJobs)
+	pool1.PushJob(getRunner(fmt.Sprintf("entry job")), wg)
+
+	//	Wait for all work to complete
+	endCh := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(endCh)
+	}()
+	select {
+	case <-endCh:
+	case <-ctx.Done():
+		t.Fatal("Test timed out")
+	}
+
+	//	Check completed versus expected jobs
+	if completedJobs != totalExpectedJobs {
+		t.Errorf("Expected %d completed jobs, but got %d", totalExpectedJobs, completedJobs)
 		return
 	}
 }


### PR DESCRIPTION
Adding new `SetGroupInputFeed()` method that takes a map of string identifier to transformer and will process the input feed by composing the transformers into a group, rather than spinning off the jobs individually. The effectively allows for a pool in the middle of a chain to parallelize and then reconstitute on a single thread in a downstream chain.

Only `SetGroupInputFeed()` or `SetInputFeed()` should be used; never both.