### PR TITLE
[FIX] fixing contract poller

### DIFF
--- a/contract_poller/api.go
+++ b/contract_poller/api.go
@@ -4,9 +4,10 @@ import "context"
 
 func (p *Poller) Insights() map[string]map[string]int {
 	return map[string]map[string]int{
-		"fetch-pool":      p.fetchPool.Insights(),
-		"accumulate-pool": p.accumulatePool.Insights(),
-		"write-pool":      p.writePool.Insights(),
+		"fetch-address-pool": p.getAddressPool.Insights(),
+		"fetch-pool":         p.fetchPool.Insights(),
+		"accumulate-pool":    p.accumulatePool.Insights(),
+		"write-pool":         p.writePool.Insights(),
 	}
 }
 
@@ -17,7 +18,7 @@ func (p *Poller) Pause() {
 	p.writePool.FlushAndRestart()
 	p.accumulatePool.FlushAndRestart()
 	p.fetchPool.FlushAndRestart()
-
+	p.getAddressPool.FlushAndRestart()
 	p.mode = ModePaused
 }
 

--- a/contract_poller/deps.go
+++ b/contract_poller/deps.go
@@ -9,9 +9,9 @@ type Driver interface {
 	Blockchain() string
 	GetChainTipNumber(ctx context.Context) (uint64, error)
 	// FetchContractAddresses involves fetching trace from ethrpc node
-	FetchContractAddresses(blockNumber uint64) map[string]pool.Runner
-	// FetchContractMetadata involves fetching contract's abi and metadata, using results from FetchContractAddresses
-	FetchContractMetadata() map[string]pool.FeedTransformer
+	FetchContractAddresses(blockNumber uint64) pool.Runner
+	// Fetchers involves fetching contract's abi and metadata, using results from FetchContractAddresses
+	Fetchers() map[string]pool.FeedTransformer
 	// Accumulate involves combining abi, metadata to form a complete contract, building fragments
 	Accumulate(res interface{}) pool.Runner
 	// Writers involves writing to postgresDB

--- a/contract_poller/util.go
+++ b/contract_poller/util.go
@@ -10,8 +10,8 @@ func (p *Poller) cacheKey() string {
 }
 
 func (p *Poller) driverTaskLoad() int {
-	//	count of fetchers + count of accumulators (always 1) + count of writers == number of queued jobs per block
-	return len(p.driver.FetchContractAddresses(0)) + 1 + len(p.driver.Writers())
+	//	count of address fetcher (1) + fetchers + count of accumulators (always 1) + count of writers == number of queued jobs per block
+	return 1 + len(p.driver.Fetchers()) + len(p.driver.Writers())
 }
 
 func modeToString(mode int) string {


### PR DESCRIPTION
This PR fixes contract poller framework logic
- Set up an input feed for fetch pool, so that functions involving fetching ABI & metadata can run after addresses are obtained from `FetchContractAddresses`
- adding options and insights for two fetch pools, instead of one