### PR TITLE
[fix] using a map of runners for fetcher 

### DIFF
--- a/contract_poller/deps.go
+++ b/contract_poller/deps.go
@@ -8,8 +8,8 @@ import (
 type Driver interface {
 	Blockchain() string
 	GetChainTipNumber(ctx context.Context) (uint64, error)
-	// FetchContractAddresses involves fetching trace from ethrpc node
-	FetchContractAddresses(blockNumber uint64) pool.Runner
+	// FetchSequence involves fetching trace and receipt from ethrpc node
+	FetchSequence(blockNumber uint64) map[string]pool.Runner
 	// Fetchers involves fetching contract's abi and metadata, using results from FetchContractAddresses
 	Fetchers() map[string]pool.FeedTransformer
 	// Accumulate involves combining abi, metadata to form a complete contract, building fragments

--- a/contract_poller/poller.go
+++ b/contract_poller/poller.go
@@ -109,7 +109,7 @@ func (p *Poller) Start(ctx context.Context) error {
 				startIndex := cursor
 				for i := 0; i < p.cfg.BatchSize; i++ {
 					wg.Add(p.driverTaskLoad())
-					p.getAddressPool.PushJob(p.driver.FetchContractAddresses(cursor), &wg)
+					p.getAddressPool.PushGroup(p.driver.FetchSequence(cursor), &wg)
 				}
 				wg.Wait()
 				cursor = startIndex + uint64(p.cfg.BatchSize)
@@ -118,7 +118,7 @@ func (p *Poller) Start(ctx context.Context) error {
 				p.logger.Infof("Chaintip mode: pulling block %d", cursor)
 				wg := sync.WaitGroup{}
 				wg.Add(p.driverTaskLoad())
-				p.getAddressPool.PushJob(p.driver.FetchContractAddresses(cursor), &wg)
+				p.getAddressPool.PushGroup(p.driver.FetchSequence(cursor), &wg)
 				wg.Wait()
 				cursor++
 			}

--- a/contract_poller/util.go
+++ b/contract_poller/util.go
@@ -10,8 +10,8 @@ func (p *Poller) cacheKey() string {
 }
 
 func (p *Poller) driverTaskLoad() int {
-	//	count of address fetcher (1) + fetchers + count of accumulators (always 1) + count of writers == number of queued jobs per block
-	return 1 + len(p.driver.Fetchers()) + len(p.driver.Writers())
+	//	count of address fetchers + fetchers + count of accumulators (always 1) + count of writers == number of queued jobs per block
+	return len(p.driver.FetchSequence(0)) + len(p.driver.Fetchers()) + len(p.driver.Writers())
 }
 
 func modeToString(mode int) string {


### PR DESCRIPTION
This PR fixes one of the fetchers, since determining contract deployments requires a field from the transaction receipt (`contractAddress`) as well as trace.
- `FetchContractAddresses` -> `FetchSequence`