### PR TITLE
[fix] fixing number of driver tasks for contract poller

### DIFF
--- a/contract_poller/util.go
+++ b/contract_poller/util.go
@@ -11,7 +11,7 @@ func (p *Poller) cacheKey() string {
 
 func (p *Poller) driverTaskLoad() int {
 	//	count of address fetchers + fetchers + count of accumulators (always 1) + count of writers == number of queued jobs per block
-	return len(p.driver.FetchSequence(0)) + len(p.driver.Fetchers()) + len(p.driver.Writers())
+	return len(p.driver.FetchSequence(0)) + len(p.driver.Fetchers()) + 1 + len(p.driver.Writers())
 }
 
 func modeToString(mode int) string {


### PR DESCRIPTION
Total number of tasks for contract_poller driver was off by 1.
formula
`# to be added to a wait group = tasks of fetchers (abi fetching + metadata fetching) + tasks of fetchSequence (responsible for fetching trace, receipt)  + Accumulator task (always 1) + writer task(insert contracts, events, methods)`
`len(p.driver.FetchSequence(0)) + len(p.driver.Fetchers()) + 1 + len(p.driver.Writers())`
